### PR TITLE
Fix regression from inverted field/rec delims

### DIFF
--- a/s3select
+++ b/s3select
@@ -105,9 +105,9 @@ class ScanOneKey(threading.Thread):
                     self.record_delimiter is not None:
 
                 if self.field_delimiter is None:
-                    self.field_delimiter = "\n"
+                    self.field_delimiter = ","
                 if self.record_delimiter is None:
-                    self.record_delimiter = ","
+                    self.record_delimiter = "\n"
 
                 input_ser = {
                     'CSV':


### PR DESCRIPTION
Commit 728788a defines default field and record delimiters that are inverted from S3 Select defaults, causing a regression when exactly one of `-d` or `-D` is given. This PR restores correct defaults.